### PR TITLE
:sparkles: Add color extracting from plantuml and color adding to edges in freemind

### DIFF
--- a/plantuml2freemind/generators/freemind.py
+++ b/plantuml2freemind/generators/freemind.py
@@ -37,7 +37,9 @@ def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
         xml_node.set('STYLE', node_data['style'])
     if node_data['link'] is not None:
         xml_node.set('LINK', node_data['link'])
-    xml_node.set('COLOR', '#425AAA')
+    if node_data['color'] is not None:
+        xml_node.set('COLOR', node_data['color'])
+
     xml_node.set('CREATED', now)
     xml_node.set('MODIFIED', now)
     if side is not None:

--- a/plantuml2freemind/generators/freemind.py
+++ b/plantuml2freemind/generators/freemind.py
@@ -32,14 +32,17 @@ def convert_tree_into_mm(root_node_data) -> str:
 
 def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
     xml_node = ET.SubElement(parent_xml_node, 'node')
+    xml_edge = ET.SubElement(xml_node, 'edge')
     xml_node.set('TEXT', node_data['text'])
     if node_data['style'] is not None:
         xml_node.set('STYLE', node_data['style'])
     if node_data['link'] is not None:
         xml_node.set('LINK', node_data['link'])
-    if node_data['edge_color'] is not None:
-        xml_edge = ET.SubElement(xml_node, 'edge')   
+    if node_data['color'] is not None:  
         xml_edge.set('COLOR', node_data['color'])
+    if node_data['width'] is not None:  
+        xml_edge.set('WIDTH', node_data['width'])
+    
 
     xml_node.set('CREATED', now)
     xml_node.set('MODIFIED', now)

--- a/plantuml2freemind/generators/freemind.py
+++ b/plantuml2freemind/generators/freemind.py
@@ -32,17 +32,14 @@ def convert_tree_into_mm(root_node_data) -> str:
 
 def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
     xml_node = ET.SubElement(parent_xml_node, 'node')
-    xml_edge = ET.SubElement(xml_node, 'edge')
     xml_node.set('TEXT', node_data['text'])
     if node_data['style'] is not None:
         xml_node.set('STYLE', node_data['style'])
     if node_data['link'] is not None:
         xml_node.set('LINK', node_data['link'])
     if node_data['color'] is not None:  
+        xml_edge = ET.SubElement(xml_node, 'edge')
         xml_edge.set('COLOR', node_data['color'])
-    if node_data['width'] is not None:  
-        xml_edge.set('WIDTH', node_data['width'])
-    
 
     xml_node.set('CREATED', now)
     xml_node.set('MODIFIED', now)

--- a/plantuml2freemind/generators/freemind.py
+++ b/plantuml2freemind/generators/freemind.py
@@ -37,8 +37,9 @@ def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
         xml_node.set('STYLE', node_data['style'])
     if node_data['link'] is not None:
         xml_node.set('LINK', node_data['link'])
-    if node_data['color'] is not None:
-        xml_node.set('COLOR', node_data['color'])
+    if node_data['edge_color'] is not None:
+        xml_edge = ET.SubElement(xml_node, 'edge')   
+        xml_edge.set('COLOR', node_data['color'])
 
     xml_node.set('CREATED', now)
     xml_node.set('MODIFIED', now)

--- a/plantuml2freemind/parsers/plantuml.py
+++ b/plantuml2freemind/parsers/plantuml.py
@@ -47,10 +47,8 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
     nesting_level = left_part.count('*')
     style = 'fork' if left_part.endswith('_') else 'bubble'
 
-    match = re.search('\[(#[a-f0-9]{6})?\|?([0-9]*)\]', left_part)
-
+    match = re.search('\[(#[a-f0-9]{6})\]', left_part)
     color = match.group(1) if match else None
-    width = match.group(2) if match else None
 
     node_data: MindmapTreeType = cast(
         MindmapTreeType,
@@ -61,8 +59,7 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
             'side': side,
             'style': style,
             'children': [],
-            'color': color,
-            'width': width
+            'color': color
         },
     )
     return node_data

--- a/plantuml2freemind/parsers/plantuml.py
+++ b/plantuml2freemind/parsers/plantuml.py
@@ -47,8 +47,10 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
     nesting_level = left_part.count('*')
     style = 'fork' if left_part.endswith('_') else 'bubble'
 
-    match = re.search('\[(#[a-f0-9]{6})\]', left_part)
-    color = match.group(1) if match else '#000000'
+    match = re.search('\[(#[a-f0-9]{6})?\|?([0-9]*)\]', left_part)
+
+    color = match.group(1) if match else None
+    width = match.group(2) if match else None
 
     node_data: MindmapTreeType = cast(
         MindmapTreeType,
@@ -59,7 +61,8 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
             'side': side,
             'style': style,
             'children': [],
-            'color': color
+            'color': color,
+            'width': width
         },
     )
     return node_data

--- a/plantuml2freemind/parsers/plantuml.py
+++ b/plantuml2freemind/parsers/plantuml.py
@@ -1,5 +1,5 @@
 from typing import List, cast
-
+import re
 from plantuml2freemind.custom_types import MindmapTreeType
 
 
@@ -46,6 +46,10 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
     left_part, right_part = line.split(' ', maxsplit=1)
     nesting_level = left_part.count('*')
     style = 'fork' if left_part.endswith('_') else 'bubble'
+
+    match = re.search('\[(#[a-f0-9]{6})\]', left_part)
+    color = match.group(1) if match else '#000000'
+
     node_data: MindmapTreeType = cast(
         MindmapTreeType,
         {
@@ -55,6 +59,7 @@ def parse_line_org_mode(line: str, side: str) -> MindmapTreeType:
             'side': side,
             'style': style,
             'children': [],
+            'color': color
         },
     )
     return node_data


### PR DESCRIPTION
Like discussed in issue #13, I've added support for colors and width. `****[#ff0000|1]_ Рефлексия` results in: `<edge COLOR="#ff0000" WIDTH="1" />`. It also works with `[#ff0000]` and `[2]`.

There is also a possibility to add support for text coloring, but looks like it doesn't have any sense now. 