### PR TITLE
:art: Add actual data structures for root, child and parser nodes

### DIFF
--- a/plantuml2freemind/custom_types.py
+++ b/plantuml2freemind/custom_types.py
@@ -1,4 +1,111 @@
-from typing import NewType, Dict, Any
+from typing import Any, Container, Dict, List, Optional
 
-# TODO: add real type: attrs is a good choice
-MindmapTreeType = NewType('MindmapTreeType', Dict[str, Any])
+from attr import asdict, attrib, attrs
+from attr.validators import in_, instance_of, optional
+
+LEFT_SIDE = 'left'
+RIGHT_SIDE = 'right'
+VALID_SIDES = frozenset([LEFT_SIDE, RIGHT_SIDE])
+
+
+def exclude_keys(d: Dict[str, Any], excluded: Container[str]) -> Dict[str, Any]:
+    return {key: value for key, value in d.items() if key not in excluded}
+
+@attrs
+class MindmapTreeNode(object):
+    text: str = attrib(validator=instance_of(str))
+    link: Optional[str] = attrib()
+    style: Optional[str] = attrib()
+    color: Optional[str] = attrib()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@attrs(kw_only=True, slots=True)
+class ChildNode(MindmapTreeNode):
+    children: List['ChildNode'] = attrib(
+        factory=list,
+    )
+
+    def get_last_child(self) -> 'ChildNode':
+        if not self.children:
+            raise ValueError('Current node has no children')
+        return self.children[-1]
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> Optional['ChildNode']:
+        if not d:
+            return None
+        node = cls(**exclude_keys(d, ['children']))
+        children = []
+        for child_dict in d.get('children', []):
+            child = cls.from_dict(child_dict)
+            if child is not None:
+                children.append(child)
+        node.children = children
+        return node
+
+
+@attrs(kw_only=True, slots=True)
+class RootNode(MindmapTreeNode):
+    right: Optional[ChildNode] = attrib(default=None, validator=optional(instance_of(ChildNode)))
+    left: Optional[ChildNode] = attrib(default=None, validator=optional(instance_of(ChildNode)))
+
+    def get_side(self, side: Optional[str]) -> Optional[ChildNode]:
+        if side == LEFT_SIDE:
+            return self.left
+        if side == RIGHT_SIDE:
+            return self.right
+        raise ValueError('{side} is not a valid value for side'.format(side=side))
+
+    def add_node(self, node: 'ParserNode'):
+        if node.level == 1:
+            raise ValueError('Trying to add a root node')
+        if node.level == 2:
+            if node.side == LEFT_SIDE:
+                self.left = node.to_child()
+            elif node.side == RIGHT_SIDE:
+                self.right = node.to_child()
+            return
+
+        child = self.get_side(node.side)
+        if child is None:
+            raise ValueError('{side} child is None'.format(side=node.side))
+        for _ in range(node.level - 3):
+            child = child.get_last_child()
+
+        child.children.append(node.to_child())
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> 'RootNode':
+        root = cls(**exclude_keys(d, VALID_SIDES))
+        left = d.get('left', {})
+        right = d.get('right', {})
+        root.left = ChildNode.from_dict(left)
+        root.right = ChildNode.from_dict(right)
+        return root
+
+
+@attrs(kw_only=True, slots=True, frozen=True)
+class ParserNode(MindmapTreeNode):
+    level: int = attrib(validator=instance_of(int))
+    side: Optional[str] = attrib(validator=optional(in_(VALID_SIDES)))
+
+    @level.validator
+    def is_positive(self, attribute, value):
+        if value < 1:
+            raise ValueError('level must be a positive integer greater than 1')
+
+    @property
+    def is_root(self) -> bool:
+        return self.level == 1
+
+    def to_node_dict(self):
+        return asdict(self, filter=lambda attr, value: attr.name not in ['level', 'side'])
+
+    def to_root(self) -> RootNode:
+        return RootNode(**self.to_node_dict())
+
+    def to_child(self) -> ChildNode:
+        return ChildNode(**self.to_node_dict())

--- a/plantuml2freemind/generators/freemind.py
+++ b/plantuml2freemind/generators/freemind.py
@@ -1,28 +1,25 @@
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from io import StringIO
-from typing import Optional
+from typing import Optional, Union
 
-from plantuml2freemind.custom_types import MindmapTreeType
+from plantuml2freemind.custom_types import RootNode, ChildNode
 
 now = str(datetime.utcnow().timestamp())
 
 
-def entry(tree: MindmapTreeType) -> str:
+def entry(tree: RootNode) -> str:
     return convert_tree_into_mm(
         root_node_data=tree,
     )
 
 
-def convert_tree_into_mm(root_node_data) -> str:
+def convert_tree_into_mm(root_node_data: RootNode) -> str:
     xml_map = ET.Element('map')
     xml_map.set('version', '1.0.1')
     root_xml_node = create_xml_node(xml_map, root_node_data, side=None)
-    for branch_name in ['left', 'right']:
-        branch = root_node_data[branch_name]
-        parent = root_xml_node
-        for node_data in branch:
-            create_xml_node_tree(parent, node_data, side=branch_name)
+    process_branch(root_xml_node, root_node_data.left, 'left')
+    process_branch(root_xml_node, root_node_data.right, 'right')
     xml_tree = ET.ElementTree(xml_map)
     file_obj = StringIO()
     xml_tree.write(file_obj, 'unicode')
@@ -30,16 +27,23 @@ def convert_tree_into_mm(root_node_data) -> str:
     return file_obj.getvalue()
 
 
-def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
+def process_branch(parent: ET.Element, branch: Optional[ChildNode], side: str):
+    if branch is None:
+        return
+    for node_data in branch.children:
+        create_xml_node_tree(parent, node_data, side)
+
+
+def create_xml_node(parent_xml_node, node: Union[RootNode, ChildNode], side: Optional[str] = None) -> ET.Element:
     xml_node = ET.SubElement(parent_xml_node, 'node')
-    xml_node.set('TEXT', node_data['text'])
-    if node_data['style'] is not None:
-        xml_node.set('STYLE', node_data['style'])
-    if node_data['link'] is not None:
-        xml_node.set('LINK', node_data['link'])
-    if node_data['color'] is not None:  
+    xml_node.set('TEXT', node.text)
+    if node.style is not None:
+        xml_node.set('STYLE', node.style)
+    if node.link is not None:
+        xml_node.set('LINK', node.link)
+    if node.color is not None:
         xml_edge = ET.SubElement(xml_node, 'edge')
-        xml_edge.set('COLOR', node_data['color'])
+        xml_edge.set('COLOR', node.color)
 
     xml_node.set('CREATED', now)
     xml_node.set('MODIFIED', now)
@@ -48,12 +52,11 @@ def create_xml_node(parent_xml_node, node_data, side: Optional[str]):
     return xml_node
 
 
-def create_xml_node_tree(parent, node_data, side: Optional[str] = None):
+def create_xml_node_tree(parent: ET.Element, node_data: ChildNode, side: Optional[str] = None):
     xml_node = create_xml_node(parent, node_data, side)
-    for child_node_data in node_data['children']:
+    for child_node_data in node_data.children:
         create_xml_node_tree(
             parent=xml_node,
             node_data=child_node_data,
         )
     return xml_node
-

--- a/plantuml2freemind/generators/yaml.py
+++ b/plantuml2freemind/generators/yaml.py
@@ -1,14 +1,14 @@
 import yaml
 
-from plantuml2freemind.custom_types import MindmapTreeType
+from plantuml2freemind.custom_types import RootNode
 
 
-def entry(tree: MindmapTreeType) -> str:
+def entry(tree: RootNode) -> str:
     # mypy distributed with fixed typeshed version and in mypy 0.740
     # it has misleading stub file for yaml library: https://github.com/python/typeshed/pull/3417
     # TODO: remove `type: ignore` after updating to 0.750 or above
     return yaml.dump_all(  # type: ignore
-        documents=[tree],
+        documents=[tree.to_dict()],
         allow_unicode=True,
         default_flow_style=False,
         sort_keys=False,

--- a/plantuml2freemind/parsers/yaml.py
+++ b/plantuml2freemind/parsers/yaml.py
@@ -1,7 +1,7 @@
 import yaml
 
-from plantuml2freemind.custom_types import MindmapTreeType
+from plantuml2freemind.custom_types import RootNode
 
 
-def entry(file_content: str) -> MindmapTreeType:
-    return yaml.safe_load(file_content)
+def entry(file_content: str) -> RootNode:
+    return RootNode.from_dict(yaml.safe_load(file_content))


### PR DESCRIPTION
Closes #19.

Added RootNode, ChildNode, and ParserNode with annotations and basic validation. I also moved add_node logic to RootNode class and started using actual classes everywhere instead of MindmapTreeType.

I've tested this locally but I'm not sure whether I checked all the major cases so I'll be grateful for an extra validation and review.